### PR TITLE
Use both screens as consoles: `stdout` and `stderr` on different screens!

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 BasedOnStyle: LLVM
 MaxEmptyLinesToKeep: 1
-ColumnLimit: 80
+ColumnLimit: 100
 ExperimentalAutoDetectBinPacking: true
 
 # Pack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,19 @@ cmake_policy(SET CMP0135 NEW)
 cmake_policy(SET CMP0077 NEW)
 project(nds-shell LANGUAGES CXX)
 
-set(CMAKE_SYSTEM_PROCESSOR "armv5te") # ARM9
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 26)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 set(BUILD_SHARED_LIBS OFF)
 
+# for some reason catnip does not do this for us?
 list(APPEND CMAKE_MODULE_PATH "$ENV{DEVKITPRO}/cmake")
+
+# grab all the nds-specific settings
 include(Platform/NintendoDS)
+
+# start fetching dependencies
 include(FetchContent)
 
 ## mbedtls
@@ -53,15 +57,19 @@ set(ENABLE_IPV6 OFF)
 set(ENABLE_THREADED_RESOLVER OFF)
 set(ENABLE_ARES OFF)
 
+# newlib doesn't have these functions
 set(HAVE_ATOMIC OFF)
 set(HAVE_BASENAME OFF)
 
-# nonblock
+# lib/curlx/nonblock.c
+# - fcntl is not implemented: https://github.com/devkitPro/newlib/tree/devkitPro/libgloss/libsysbase (no fcntl.c file)
+# - setsockopt() does nothing: https://github.com/devkitPro/dswifi/blob/f61bbc661dc7087fc5b354cd5ec9a878636d4cbf/source/sgIP/sgIP_sockets.c#L407
+# - dswifi provides ioctl() with FIONBIO flag: https://github.com/devkitPro/dswifi/blob/f61bbc661dc7087fc5b354cd5ec9a878636d4cbf/source/sgIP/sgIP_sockets.c#L372
 set(HAVE_FCNTL_O_NONBLOCK OFF)
 set(HAVE_SETSOCKOPT_SO_NONBLOCK OFF)
 set(HAVE_IOCTL_FIONBIO ON)
 
-# socket api
+# socket api: https://github.com/devkitPro/dswifi/blob/master/source/sgIP/sgIP_sockets.c
 set(HAVE_SOCKET ON)
 set(HAVE_SELECT ON)
 set(HAVE_RECV ON)
@@ -100,9 +108,10 @@ FetchContent_MakeAvailable(sol2)
 
 add_compile_options(-fno-rtti -fno-exceptions)
 add_compile_definitions(SOL_EXCEPTIONS=0)
-include_directories(include ${curl_SOURCE_DIR}/include)
-link_libraries(dswifi9 fat nds9 lua_static sol2 libcurl)
+include_directories(include ${curl_SOURCE_DIR}/include /home/t/libnds/include)
+link_directories(/home/t/libnds/lib) # hopefully this is temporary, it will fail CI for now
+link_libraries(dswifi9 fat lua_static sol2 libcurl)
 
-file(GLOB_RECURSE SOURCES src/**)
+file(GLOB_RECURSE SOURCES src/*.cpp)
 add_executable(nds-shell ${SOURCES})
 nds_create_rom(nds-shell)

--- a/src/commands/curl.cpp
+++ b/src/commands/curl.cpp
@@ -14,6 +14,8 @@ curl_debug(CURL *, curl_infotype, char *const data, const size_t size, void *)
 	return 0;
 }
 
+// this was extremely painful to discover:
+// https://github.com/devkitPro/dswifi/blob/f61bbc661dc7087fc5b354cd5ec9a878636d4cbf/source/sgIP/sgIP_sockets.c#L98
 static curl_socket_t
 curl_opensocket(void *, curlsocktype, curl_sockaddr *const addr)
 {

--- a/src/commands/wifi.cpp
+++ b/src/commands/wifi.cpp
@@ -379,7 +379,7 @@ void subcommand_autoconnect()
 
 	if (status == ASSOCSTATUS_CANNOTCONNECT)
 	{
-		*Shell::err << "\e[41mwifi: connection failed\n\e[39m";
+		*Shell::err << "\e[41mwifi: autoconnect failed\n\e[39m";
 		return;
 	}
 


### PR DESCRIPTION
- This involved [patching libnds's `console.c`](https://github.com/trustytrojan/libnds/blob/b1c5d902fff962c260083ef87d87edf1bc340da2/source/arm9/console.c) to use a different console for writes to `stderr`
- It exploits the fact that [the standard I/O `__handle` structs in newlib are accessible via the `__get_handle` function](https://github.com/devkitPro/newlib/blob/4cc8767a6067786cbb2da969baff3481bd71461c/libgloss/libsysbase/handle_manager.c#L88-L97)!
  - All that applications need to do is set the `fileStruct` field on the `__stderr_handle` (accessible via `__get_handle(2)`) to any pointer. In this case I point it to a static integer containing `2`, since that's what my libnds patch checks for.
  - This is great because I don't need to PR or deal with rebuilding newlib!
- Closes #7
- With enough effort in the fork I could get https://github.com/devkitPro/libnds/issues/69 closed as well
- **TODO:** change the CMake build system to use my libnds fork instead of the one provided by dkp-pacman